### PR TITLE
Abstract Types extension to WebAssembly's reference types proposal

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -58,6 +58,12 @@ let at f s =
 
 
 
+(* FIXME add support for abstract types *)
+let fixme_w vt = Types.RawValueType vt
+let fixme_wl = List.map fixme_w
+
+
+
 (* Generic values *)
 
 let u8 s =
@@ -163,7 +169,7 @@ let func_type s =
   | -0x20 ->
     let ins = vec value_type s in
     let out = vec value_type s in
-    FuncType (ins, out)
+    FuncType (fixme_wl ins, fixme_wl out)
   | _ -> error s (pos s - 1) "invalid function type"
 
 let limits vu s =

--- a/interpreter/host/env.ml
+++ b/interpreter/host/env.ml
@@ -7,6 +7,7 @@
 open Values
 open Types
 open Instance
+open Extern_types
 
 
 let error msg = raise (Eval.Crash (Source.no_region, msg))
@@ -41,6 +42,8 @@ let exit vs =
 
 let lookup name t =
   match Utf8.encode name, t with
-  | "abort", ExternFuncType t -> ExternFunc (Func.alloc_host t abort)
-  | "exit", ExternFuncType t -> ExternFunc (Func.alloc_host t exit)
+  | "abort", ExternFuncType et ->
+    ExternFunc (Func.alloc_host (func_type_from_extern et) abort)
+  | "exit", ExternFuncType et ->
+    ExternFunc (Func.alloc_host (func_type_from_extern et) exit)
   | _ -> raise Not_found

--- a/interpreter/host/spectest.ml
+++ b/interpreter/host/spectest.ml
@@ -15,6 +15,9 @@ let global (GlobalType (t, _) as gt) =
     | NumType F32Type -> Num (F32 (F32.of_float 666.6))
     | NumType F64Type -> Num (F64 (F64.of_float 666.6))
     | RefType _ -> Ref NullRef
+    (* Start: Abstract Types *)
+    | SealedAbsType _ -> assert false
+    (* Start: Abstract Types *)
     | BotType -> assert false
   in Global.alloc gt v
 
@@ -31,19 +34,19 @@ let print_value v =
 let print (FuncType (_, out)) vs =
   List.iter print_value vs;
   flush_all ();
-  List.map default_value out
-
+  List.map (fun v -> default_value (unwrap v)) out
 
 let lookup name t =
+  let open Types_shorthand in
   match Utf8.encode name, t with
   | "print", _ -> ExternFunc (func print (FuncType ([], [])))
-  | "print_i32", _ -> ExternFunc (func print (FuncType ([NumType I32Type], [])))
+  | "print_i32", _ -> ExternFunc (func print (FuncType ([r (NumType I32Type)], [])))
   | "print_i32_f32", _ ->
-    ExternFunc (func print (FuncType ([NumType I32Type; NumType F32Type], [])))
+    ExternFunc (func print (FuncType ([r (NumType I32Type); r (NumType F32Type)], [])))
   | "print_f64_f64", _ ->
-    ExternFunc (func print (FuncType ([NumType F64Type; NumType F64Type], [])))
-  | "print_f32", _ -> ExternFunc (func print (FuncType ([NumType F32Type], [])))
-  | "print_f64", _ -> ExternFunc (func print (FuncType ([NumType F64Type], [])))
+    ExternFunc (func print (FuncType ([r (NumType F64Type); r (NumType F64Type)], [])))
+  | "print_f32", _ -> ExternFunc (func print (FuncType ([r (NumType F32Type)], [])))
+  | "print_f64", _ -> ExternFunc (func print (FuncType ([r (NumType F64Type)], [])))
   | "global_i32", _ -> ExternGlobal (global (GlobalType (NumType I32Type, Immutable)))
   | "global_f32", _ -> ExternGlobal (global (GlobalType (NumType F32Type, Immutable)))
   | "global_f64", _ -> ExternGlobal (global (GlobalType (NumType F64Type, Immutable)))

--- a/interpreter/main/main.ml
+++ b/interpreter/main/main.ml
@@ -6,7 +6,7 @@ let configure () =
   Import.register (Utf8.decode "env") Env.lookup
 
 let banner () =
-  print_endline (name ^ " " ^ version ^ " reference interpreter")
+  print_endline (name ^ " " ^ version ^ " reference interpreter + abstract types")
 
 let usage = "Usage: " ^ name ^ " [option] [file ...]"
 

--- a/interpreter/runtime/extern_types.ml
+++ b/interpreter/runtime/extern_types.ml
@@ -1,0 +1,250 @@
+open Types
+open Instance
+
+(* Fundamentally, abstract types are based on Module (or Host) instances,
+   not module definitions. The additional constructors (NameModuleRef, 
+   LocalModuleRef) exist to assist with representing abstract types
+   in contexts were modules haven't been instantiated yet, but these
+   representations of abstract types have to be resolved before they
+   can be properly compared. *)
+type unresolved_abstype_ref =
+  | NamedModuleAbsRef of Ast.name * Ast.name
+  | LocalModuleAbsRef of int32
+
+type resolved_abstype_ref =
+  | InstModuleAbsRef of sealed_abstype_inst
+(* FIXME host abstract types are not currently supported *)
+(* | HostModuleAbsRef *)
+
+type 'absref extern_value_type =
+  | ExternNumType of num_type
+  | ExternRefType of ref_type
+  | ExternSealedAbsType of 'absref
+  | ExternBotType
+
+type 'absref extern_stack_type = 'absref extern_value_type list
+
+type 'absref extern_func_type =
+  | ExternFuncSigType of
+      'absref extern_stack_type * 'absref extern_stack_type * func_type
+
+type resolved_extern_func_type = resolved_abstype_ref extern_func_type
+
+type 'absref extern_type =
+  | ExternAbsType of 'absref
+  | ExternFuncType of 'absref extern_func_type
+  | ExternTableType of table_type
+  | ExternMemoryType of memory_type
+  | ExternGlobalType of global_type
+
+type unresolved_extern_type = unresolved_abstype_ref extern_type
+type resolved_extern_type = resolved_abstype_ref extern_type
+
+
+(* Comparisons *)
+
+let match_resolved_value_type vt1 vt2 =
+  match vt1, vt2 with
+  | ExternNumType vt1', ExternNumType vt2' -> match_num_type vt1' vt2'
+  | ExternRefType vt1', ExternRefType vt2' -> match_ref_type vt1' vt2'
+  | ExternSealedAbsType vt1', ExternSealedAbsType vt2' ->
+    (match vt1', vt2' with
+    | InstModuleAbsRef (r1, i1), InstModuleAbsRef (r2, i2) -> r1 == r2 && i1 = i2
+    )
+  | ExternBotType, _ -> true
+  | _, _ -> false
+
+let match_resolved_stack_types st1 st2 =
+  List.length st1 = List.length st2 &&
+  List.for_all2 match_resolved_value_type st1 st2
+
+let match_resolved_func_type
+    (ft1 : resolved_extern_func_type)
+    (ft2 : resolved_extern_func_type) =
+  let ExternFuncSigType (ins1, out1, _) = ft1 in
+  let ExternFuncSigType (ins2, out2, _) = ft2 in
+  match_resolved_stack_types ins1 ins2 && match_resolved_stack_types out1 out2
+
+
+(* Type Conversions *)
+
+let func_type_from_extern = function ExternFuncSigType (_, _, ft) -> ft
+
+let extern_from_value_type handle_sealed_abstype vt =
+  match vt with
+  | NumType n -> ExternNumType n
+  | RefType r -> ExternRefType r
+  | SealedAbsType i -> ExternSealedAbsType (handle_sealed_abstype i)
+  | BotType -> ExternBotType
+
+let extern_from_wrapped_value_type handle_new_abstype handle_sealed_abstype vt =
+  match vt with
+  | RawValueType vt -> extern_from_value_type handle_sealed_abstype vt
+  | NewAbsType (vt, i) -> handle_new_abstype i
+
+let extern_from_func_type
+    (handle_new_abstype : int32 -> 'absref extern_value_type)
+    (handle_sealed_abstype : int32 -> 'absref)
+    (ft : func_type) =
+  let (FuncType (ins, outs)) = ft in
+  let externalize_vt =
+    extern_from_wrapped_value_type handle_new_abstype handle_sealed_abstype
+  in
+  let externalize l = List.map externalize_vt l in
+  ExternFuncSigType (externalize ins, externalize outs, ft)
+
+
+(* Type Conversions: Unresolved *)
+
+open Ast
+open Source
+
+let local_seal_new_abstype i = ExternSealedAbsType (LocalModuleAbsRef i)
+
+let imported_sealed_abstype (m : module_) i =
+  let sealed_abstypes =
+    Lib.List.map_filter
+      (fun im ->
+        match im.it.idesc.it with AbsTypeImport x -> Some im.it | _ -> None)
+      m.it.imports
+  in
+  let im = Lib.List32.nth sealed_abstypes i in
+  NamedModuleAbsRef (im.module_name, im.item_name)
+
+let local_extern_func_type (m : module_) =
+  extern_from_func_type local_seal_new_abstype (imported_sealed_abstype m)
+
+
+(* Type Conversions: Resolved *)
+
+let inst_seal_new_abstype hinst i =
+  match hinst with
+  | ModuleInst inst -> ExternSealedAbsType (InstModuleAbsRef (inst.uid, i))
+  | HostInst -> assert false
+
+let inst_resolve_sealed_abstype hinst i =
+  match hinst with
+  | ModuleInst inst -> InstModuleAbsRef (Lib.List32.nth inst.sealed_abstypes i)
+  | HostInst -> assert false
+
+let resolve_extern_func_type (hinst : host_module_inst) =
+  extern_from_func_type
+    (inst_seal_new_abstype hinst)
+    (inst_resolve_sealed_abstype hinst)
+
+open Func
+
+let extern_type_of_func = function
+  | AstFunc (ft, inst, _) -> resolve_extern_func_type (ModuleInst !inst) ft
+  | HostFunc (ft, _) -> resolve_extern_func_type HostInst ft
+
+let extern_type_of = function
+  | ExternAbsTypeInst sealed -> ExternAbsType (InstModuleAbsRef sealed)
+  | ExternFunc func -> ExternFuncType (extern_type_of_func func)
+  | ExternTable tab -> ExternTableType (Table.type_of tab)
+  | ExternMemory mem -> ExternMemoryType (Memory.type_of mem)
+  | ExternGlobal glob -> ExternGlobalType (Global.type_of glob)
+
+
+(* Filters *)
+
+let funcs =
+  Lib.List.map_filter (function ExternFuncType t -> Some t | _ -> None)
+let tables =
+  Lib.List.map_filter (function ExternTableType t -> Some t | _ -> None)
+let memories =
+  Lib.List.map_filter (function ExternMemoryType t -> Some t | _ -> None)
+let globals =
+  Lib.List.map_filter (function ExternGlobalType t -> Some t | _ -> None)
+
+
+(* Import/Export Conversions *)
+
+let func_type_module (m : module_) (x : var) : func_type =
+  (Lib.List32.nth m.it.types x.it).it
+
+let func_type_inst (m : module_inst) (x : var) : func_type =
+  Lib.List32.nth m.types x.it
+
+let sealed_abstype_for (inst : module_inst) (x : var) : sealed_abstype_inst =
+  Lib.List32.nth inst.sealed_abstypes x.it
+
+let unresolved_import_type (m : module_) (im : import) : unresolved_extern_type =
+  let {module_name; item_name; idesc; _} = im.it in
+  match idesc.it with
+  | AbsTypeImport x ->
+    ExternAbsType (NamedModuleAbsRef (module_name, item_name))
+  | FuncImport x -> ExternFuncType (local_extern_func_type m (func_type_module m x))
+  | TableImport t -> ExternTableType t
+  | MemoryImport t -> ExternMemoryType t
+  | GlobalImport t -> ExternGlobalType t
+
+let unresolved_export_type (m : module_) (ex : export) : unresolved_extern_type =
+  let {edesc; _} = ex.it in
+  let its = List.map (unresolved_import_type m) m.it.imports in
+  let open Lib.List32 in
+  match edesc.it with
+  | AbsTypeExport x -> ExternAbsType (LocalModuleAbsRef x.it)
+  | FuncExport x ->
+    let fts =
+      funcs its
+      @ List.map
+          (fun f -> local_extern_func_type m (func_type_module m f.it.ftype))
+          m.it.funcs
+    in
+    ExternFuncType (nth fts x.it)
+  | TableExport x ->
+    let tts = tables its @ List.map (fun t -> t.it.ttype) m.it.tables in
+    ExternTableType (nth tts x.it)
+  | MemoryExport x ->
+    let mts = memories its @ List.map (fun m -> m.it.mtype) m.it.memories in
+    ExternMemoryType (nth mts x.it)
+  | GlobalExport x ->
+    let gts = globals its @ List.map (fun g -> g.it.gtype) m.it.globals in
+    ExternGlobalType (nth gts x.it)
+
+
+(* Debugging *)
+
+let string_of_unresolved_abstype = function
+  | NamedModuleAbsRef (mname, iname) ->
+    "abs{'" ^ Ast.string_of_name iname ^ "','" ^ Ast.string_of_name mname ^ "'}"
+  | LocalModuleAbsRef i -> "abs{" ^ Int32.to_string i ^ "}"
+
+let string_of_resolved_abstype = function
+  | InstModuleAbsRef (ModuleInstUID uid, i) ->
+    "abs{" ^ Int32.to_string uid ^ "," ^ Int32.to_string i ^ "}"
+
+(* NOTE: these should behave similarly to string funcs in Types *)
+
+let string_of_extern_value_type strabs = function
+  | ExternNumType n -> string_of_num_type n
+  | ExternRefType r -> string_of_ref_type r
+  | ExternSealedAbsType a -> strabs a
+  | ExternBotType -> "impossible"
+
+let string_of_extern_stack_type strabs ts =
+  "[" ^ String.concat " " (List.map (string_of_extern_value_type strabs) ts) ^ "]"
+
+let string_of_extern_func_type
+    (strabs : 'absref -> string)
+    (ExternFuncSigType (ins, out, _)) =
+  let ins_str = string_of_extern_stack_type strabs ins in
+  let out_str = string_of_extern_stack_type strabs out in
+  ins_str ^ " -> " ^ out_str
+
+let annotation_of_extern_type
+    (strabs : 'absref -> string)
+    (et : 'absref extern_type) =
+  match et with
+  | ExternAbsType t -> ("abstype", strabs t)
+  | ExternFuncType t -> ("func", string_of_extern_func_type strabs t)
+  | ExternTableType t -> ("table", string_of_table_type t)
+  | ExternMemoryType t -> ("memory", string_of_memory_type t)
+  | ExternGlobalType t -> ("global", string_of_global_type t)
+
+let annotation_of_unresolved_extern_type =
+  annotation_of_extern_type string_of_unresolved_abstype
+
+let annotation_of_resolved_extern_type =
+  annotation_of_extern_type string_of_resolved_abstype

--- a/interpreter/script/import.ml
+++ b/interpreter/script/import.ml
@@ -1,5 +1,6 @@
 open Source
 open Ast
+open Extern_types
 
 module Unknown = Error.Make ()
 exception Unknown = Unknown.Error  (* indicates unknown import name *)
@@ -11,7 +12,7 @@ let register name lookup = registry := Registry.add name lookup !registry
 
 let lookup (m : module_) (im : import) : Instance.extern =
   let {module_name; item_name; idesc} = im.it in
-  let t = import_type m im in
+  let t = unresolved_import_type m im in
   try Registry.find module_name !registry item_name t with Not_found ->
     Unknown.error im.at
       ("unknown import \"" ^ string_of_name module_name ^

--- a/interpreter/script/import.mli
+++ b/interpreter/script/import.mli
@@ -4,5 +4,8 @@ val link : Ast.module_ -> Instance.extern list (* raises Unknown *)
 
 val register :
   Ast.name ->
-  (Ast.name -> Types.extern_type -> Instance.extern (* raises Not_found *)) ->
+  (Ast.name ->
+   Extern_types.unresolved_extern_type ->
+   Instance.extern (* raises Not_found *)
+  ) ->
   unit

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -255,6 +255,7 @@ let value v =
   | Values.Ref (HostRef n) ->
     [Const (Values.I32 n @@ v.at) @@ v.at; Call (hostref_idx @@ v.at) @@ v.at]
   | Values.Ref _ -> assert false
+  | Values.SealedAbs _ -> raise_no_abstypes v.at
 
 let invoke ft vs at =
   [ft @@ at], FuncImport (subject_type_idx @@ at) @@ at,
@@ -289,6 +290,8 @@ let assert_return ress ts at =
         BrIf (0l @@ at) @@ at ]
     | LitResult {it = Values.Ref _; _} ->
       assert false
+    | LitResult {it = Values.SealedAbs _; _} ->
+      raise_no_abstypes at
     | NanResult nanop ->
       let nan =
         match nanop.it with

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -209,26 +209,18 @@ let input_stdin run =
 (* Printing *)
 
 let print_import m im =
-  let open Types in
+  let open Extern_types in
   let category, annotation =
-    match Ast.import_type m im with
-    | ExternFuncType t -> "func", string_of_func_type t
-    | ExternTableType t -> "table", string_of_table_type t
-    | ExternMemoryType t -> "memory", string_of_memory_type t
-    | ExternGlobalType t -> "global", string_of_global_type t
+    annotation_of_unresolved_extern_type (unresolved_import_type m im)
   in
   Printf.printf "  import %s \"%s\" \"%s\" : %s\n"
     category (Ast.string_of_name im.it.Ast.module_name)
       (Ast.string_of_name im.it.Ast.item_name) annotation
 
 let print_export m ex =
-  let open Types in
+  let open Extern_types in
   let category, annotation =
-    match Ast.export_type m ex with
-    | ExternFuncType t -> "func", string_of_func_type t
-    | ExternTableType t -> "table", string_of_table_type t
-    | ExternMemoryType t -> "memory", string_of_memory_type t
-    | ExternGlobalType t -> "global", string_of_global_type t
+    annotation_of_unresolved_extern_type (unresolved_export_type m ex)
   in
   Printf.printf "  export %s \"%s\" : %s\n"
     category (Ast.string_of_name ex.it.Ast.name) annotation
@@ -339,7 +331,7 @@ let run_action act : Values.value list =
       List.iter2 (fun v t ->
         if not (Types.match_value_type (Values.type_of_value v.it) t) then
           Script.error v.at "wrong type of argument"
-      ) vs ins;
+      ) vs (Types.unwrap_stack ins);
       Eval.invoke f (List.map (fun v -> v.it) vs)
     | Some _ -> Assert.error act.at "export is not a function"
     | None -> Assert.error act.at "undefined export"

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -109,6 +109,7 @@ let type_ (t : type_) = empty
 
 let export_desc (d : export_desc) =
   match d.it with
+  | AbsTypeExport x -> empty
   | FuncExport x -> funcs (var x)
   | TableExport x -> tables (var x)
   | MemoryExport x -> memories (var x)
@@ -116,6 +117,7 @@ let export_desc (d : export_desc) =
 
 let import_desc (d : import_desc) =
   match d.it with
+  | AbsTypeImport x -> empty
   | FuncImport x -> types (var x)
   | TableImport tt -> empty
   | MemoryImport mt -> empty

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -2,21 +2,32 @@
 
 type num_type = I32Type | I64Type | F32Type | F64Type
 type ref_type = NullRefType | AnyRefType | FuncRefType
-type value_type = NumType of num_type | RefType of ref_type | BotType
-type stack_type = value_type list
-type func_type = FuncType of stack_type * stack_type
+type value_type =
+  | NumType of num_type
+  | RefType of ref_type
+  (* Start: Abstract Types *)
+  | SealedAbsType of int32
+  (* End: Abstract Types *)
+  | BotType
+type raw_stack_type = value_type list
+
+type wrapped_value_type =
+  | RawValueType of value_type
+  | NewAbsType of value_type * int32
+type wrapped_stack_type = wrapped_value_type list
+type func_type = FuncType of wrapped_stack_type * wrapped_stack_type
 
 type 'a limits = {min : 'a; max : 'a option}
 type mutability = Immutable | Mutable
 type table_type = TableType of Int32.t limits * ref_type
 type memory_type = MemoryType of Int32.t limits
 type global_type = GlobalType of value_type * mutability
-type extern_type =
-  | ExternFuncType of func_type
-  | ExternTableType of table_type
-  | ExternMemoryType of memory_type
-  | ExternGlobalType of global_type
 
+let unwrap = function
+  | RawValueType vt -> vt
+  | NewAbsType (vt, _) -> vt
+
+let unwrap_stack = List.map unwrap
 
 (* Attributes *)
 
@@ -40,6 +51,9 @@ let match_value_type t1 t2 =
   match t1, t2 with
   | NumType t1', NumType t2' -> match_num_type t1' t2'
   | RefType t1', RefType t2' -> match_ref_type t1' t2'
+  (* Start: Abstract Types *)
+  | SealedAbsType a1, SealedAbsType a2 -> a1 = a2
+  (* End: Abstract Types *)
   | BotType, _ -> true
   | _, _ -> false
 
@@ -63,33 +77,19 @@ let match_global_type (GlobalType (t1, mut1)) (GlobalType (t2, mut2)) =
   mut1 = mut2 &&
   (t1 = t2 || mut2 = Immutable && match_value_type t1 t2)
 
-let match_extern_type et1 et2 =
-  match et1, et2 with
-  | ExternFuncType ft1, ExternFuncType ft2 -> match_func_type ft1 ft2
-  | ExternTableType tt1, ExternTableType tt2 -> match_table_type tt1 tt2
-  | ExternMemoryType mt1, ExternMemoryType mt2 -> match_memory_type mt1 mt2
-  | ExternGlobalType gt1, ExternGlobalType gt2 -> match_global_type gt1 gt2
-  | _, _ -> false
-
 let is_num_type = function
   | NumType _ | BotType -> true
   | RefType _ -> false
+  (* Start: Abstract Types *)
+  | SealedAbsType _ -> false
+  (* End: Abstract Types *)
 
 let is_ref_type = function
   | NumType _ -> false
   | RefType _ | BotType -> true
-
-
-(* Filters *)
-
-let funcs =
-  Lib.List.map_filter (function ExternFuncType t -> Some t | _ -> None)
-let tables =
-  Lib.List.map_filter (function ExternTableType t -> Some t | _ -> None)
-let memories =
-  Lib.List.map_filter (function ExternMemoryType t -> Some t | _ -> None)
-let globals =
-  Lib.List.map_filter (function ExternGlobalType t -> Some t | _ -> None)
+  (* Start: Abstract Types *)
+  | SealedAbsType _ -> false
+  (* End: Abstract Types *)
 
 
 (* String conversion *)
@@ -108,7 +108,14 @@ let string_of_ref_type = function
 let string_of_value_type = function
   | NumType t -> string_of_num_type t
   | RefType t -> string_of_ref_type t
+  (* Start: Abstract Types *)
+  | SealedAbsType i -> "abs{" ^ Int32.to_string i ^ "}"
+  (* End: Abstract Types *)
   | BotType -> "impossible"
+
+let string_of_wrapped_value_type = function
+  | RawValueType vt -> string_of_value_type vt
+  | NewAbsType (vt, i) -> "new abstype [" ^ string_of_value_type vt ^ "]"
 
 let string_of_value_types = function
   | [t] -> string_of_value_type t
@@ -129,14 +136,11 @@ let string_of_global_type = function
   | GlobalType (t, Immutable) -> string_of_value_type t
   | GlobalType (t, Mutable) -> "(mut " ^ string_of_value_type t ^ ")"
 
-let string_of_stack_type ts =
+let string_of_raw_stack_type ts =
   "[" ^ String.concat " " (List.map string_of_value_type ts) ^ "]"
 
-let string_of_func_type (FuncType (ins, out)) =
-  string_of_stack_type ins ^ " -> " ^ string_of_stack_type out
+let string_of_wrapped_stack_type ts =
+  "[" ^ String.concat " " (List.map string_of_wrapped_value_type ts) ^ "]"
 
-let string_of_extern_type = function
-  | ExternFuncType ft -> "func " ^ string_of_func_type ft
-  | ExternTableType tt -> "table " ^ string_of_table_type tt
-  | ExternMemoryType mt -> "memory " ^ string_of_memory_type mt
-  | ExternGlobalType gt -> "global " ^ string_of_global_type gt
+let string_of_func_type (FuncType (ins, out)) =
+  string_of_wrapped_stack_type ins ^ " -> " ^ string_of_wrapped_stack_type out

--- a/interpreter/syntax/types_shorthand.ml
+++ b/interpreter/syntax/types_shorthand.ml
@@ -1,0 +1,5 @@
+open Types
+
+let r vt = RawValueType vt
+
+let a vt i = NewAbsType (vt, i)

--- a/interpreter/syntax/values.ml
+++ b/interpreter/syntax/values.ml
@@ -11,7 +11,7 @@ type num = (I32.t, I64.t, F32.t, F64.t) op
 type ref_ = ..
 type ref_ += NullRef
 
-type value = Num of num | Ref of ref_
+type value = Num of num | Ref of ref_ | SealedAbs of int32
 
 
 (* Typing *)
@@ -28,17 +28,18 @@ let type_of_ref r = !type_of_ref' r
 let type_of_value = function
   | Num n -> NumType (type_of_num n)
   | Ref r -> RefType (type_of_ref r)
+  | SealedAbs i -> SealedAbsType i
 
 
 (* Projections *)
 
 let as_num = function
   | Num n -> n
-  | Ref _ -> failwith "as_num"
+  | _ -> failwith "as_num"
 
 let as_ref = function
-  | Num _ -> failwith "as_ref"
   | Ref r -> r
+  | _ -> failwith "as_ref"
 
 
 (* Defaults *)
@@ -55,9 +56,7 @@ let default_ref = function
 let default_value = function
   | NumType t' -> Num (default_num t')
   | RefType t' -> Ref (default_ref t')
-  (* Start: Abstract Types *)
-  | SealedAbsType _ -> assert false
-  (* End: Abstract Types *)
+  | SealedAbsType i -> SealedAbs i
   | BotType -> assert false
 
 
@@ -74,9 +73,12 @@ let string_of_num = function
 let string_of_ref' = ref (function NullRef -> "null" | _ -> "ref")
 let string_of_ref r = !string_of_ref' r
 
+let string_of_sealedabs i = "must_init{" ^ Int32.to_string i ^ "}"
+
 let string_of_value = function
   | Num n -> string_of_num n
   | Ref r -> string_of_ref r
+  | SealedAbs i -> string_of_sealedabs i
 
 let string_of_values = function
   | [v] -> string_of_value v

--- a/interpreter/syntax/values.ml
+++ b/interpreter/syntax/values.ml
@@ -55,6 +55,9 @@ let default_ref = function
 let default_value = function
   | NumType t' -> Num (default_num t')
   | RefType t' -> Ref (default_ref t')
+  (* Start: Abstract Types *)
+  | SealedAbsType _ -> assert false
+  (* End: Abstract Types *)
   | BotType -> assert false
 
 

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -183,6 +183,13 @@ rule token = parse
   | "ref.host" { REF_HOST }
   | "ref.is_null" { REF_IS_NULL }
 
+  (* Start: Abstract Types *)
+  | "abstype_new" { ABSTYPE_NEW }
+  | "abstype_new_ref" { ABSTYPE_NEW_REF }
+  | "abstype_sealed" { ABSTYPE_SEALED }
+  | "abstype_sealed_ref" { ABSTYPE_SEALED_REF }
+  (* End: Abstract Types *)
+
   | "nop" { NOP }
   | "unreachable" { UNREACHABLE }
   | "drop" { DROP }

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -1,6 +1,7 @@
 open Ast
 open Source
 open Types
+open Extern_types
 
 
 (* Errors *)
@@ -16,6 +17,13 @@ let require b at s = if not b then error at s
 
 type context =
 {
+  (* Start: Abstract Type *)
+  (* NOTE: since within-module abstract types are just treated as
+     normal value_types, this property is only used for SealedAbsTypes.
+     The int items in the list represent global IDs for the SealedAbsTypes.
+   *)
+  sealed_abstypes : unresolved_abstype_ref list;
+  (* End: Abstract Type *)
   types : func_type list;
   funcs : func_type list;
   tables : table_type list;
@@ -25,12 +33,15 @@ type context =
   datas : unit list;
   locals : value_type list;
   results : value_type list;
-  labels : stack_type list;
+  labels : raw_stack_type list;
   refs : Free.t;
 }
 
 let empty_context =
-  { types = []; funcs = []; tables = []; memories = [];
+  (* Start: Abstract Type *)
+  { sealed_abstypes = [];
+  (* End: Abstract Type *)
+    types = []; funcs = []; tables = []; memories = [];
     globals = []; elems = []; datas = [];
     locals = []; results = []; labels = [];
     refs = Free.empty
@@ -80,8 +91,8 @@ let (-->...) ts1 ts2 = {ins = Ellipses, ts1; outs = Ellipses, ts2}
 let check_stack ts1 ts2 at =
   require
     (List.length ts1 = List.length ts2 && List.for_all2 match_value_type ts1 ts2) at
-    ("type mismatch: operator requires " ^ string_of_stack_type ts2 ^
-     " but stack has " ^ string_of_stack_type ts1)
+    ("type mismatch: operator requires " ^ string_of_raw_stack_type ts2 ^
+     " but stack has " ^ string_of_raw_stack_type ts1)
 
 let pop (ell1, ts1) (ell2, ts2) at =
   let n1 = List.length ts1 in
@@ -239,7 +250,7 @@ let rec check_instr (c : context) (e : instr) (s : infer_stack_type) : op_type =
 
   | Call x ->
     let FuncType (ins, out) = func c x in
-    ins --> out
+    unwrap_stack ins --> unwrap_stack out
 
   | CallIndirect (x, y) ->
     let TableType (lim, t) = table c x in
@@ -247,7 +258,7 @@ let rec check_instr (c : context) (e : instr) (s : infer_stack_type) : op_type =
     require (match_ref_type t FuncRefType) x.at
       ("type mismatch: instruction requires table of functions" ^
        " but table has " ^ string_of_ref_type t);
-    (ins @ [NumType I32Type]) --> out
+    (unwrap_stack ins @ [NumType I32Type]) --> unwrap_stack out
 
   | LocalGet x ->
     [] --> [local c x]
@@ -388,12 +399,12 @@ and check_seq (c : context) (es : instr list) : infer_stack_type =
     let {ins; outs} = check_instr c e s in
     push outs (pop ins s e.at)
 
-and check_block (c : context) (es : instr list) (ts : stack_type) at =
+and check_block (c : context) (es : instr list) (ts : raw_stack_type) at =
   let s = check_seq c es in
   let s' = pop (stack ts) s at in
   require (snd s' = []) at
-    ("type mismatch: operator requires " ^ string_of_stack_type ts ^
-     " but stack has " ^ string_of_stack_type (snd s))
+    ("type mismatch: operator requires " ^ string_of_raw_stack_type ts ^
+     " but stack has " ^ string_of_raw_stack_type (snd s))
 
 
 (* Types *)
@@ -417,12 +428,18 @@ let check_value_type (t : value_type) at =
   match t with
   | NumType t' -> check_num_type t' at
   | RefType t' -> check_ref_type t' at
+  | SealedAbsType i -> ()
   | BotType -> ()
+
+let check_wrapped_value_type (t : wrapped_value_type) at =
+  match t with
+  | RawValueType vt -> check_value_type vt at
+  | NewAbsType (vt, i) -> check_value_type vt at
 
 let check_func_type (ft : func_type) at =
   let FuncType (ins, out) = ft in
-  List.iter (fun t -> check_value_type t at) ins;
-  List.iter (fun t -> check_value_type t at) out;
+  List.iter (fun t -> check_wrapped_value_type t at) ins;
+  List.iter (fun t -> check_wrapped_value_type t at) out;
   check_arity (List.length out) at
 
 let check_table_type (tt : table_type) at =
@@ -460,8 +477,10 @@ let check_type (t : type_) =
 let check_func (c : context) (f : func) =
   let {ftype; locals; body} = f.it in
   let FuncType (ins, out) = type_ c ftype in
-  let c' = {c with locals = ins @ locals; results = out; labels = [out]} in
-  check_block c' body out f.at
+  let raw_out = unwrap_stack out in
+  let c' = {c with locals = unwrap_stack ins @ locals;
+                   results = raw_out; labels = [raw_out]} in
+  check_block c' body raw_out f.at
 
 
 let is_const (c : context) (e : instr) =
@@ -530,8 +549,10 @@ let check_start (c : context) (start : var option) =
   ) start
 
 let check_import (im : import) (c : context) : context =
-  let {module_name = _; item_name = _; idesc} = im.it in
+  let {module_name = mname; item_name = iname; idesc} = im.it in
   match idesc.it with
+  | AbsTypeImport x ->
+    {c with sealed_abstypes = NamedModuleAbsRef (mname, iname) :: c.sealed_abstypes }
   | FuncImport x ->
     {c with funcs = type_ c x :: c.funcs}
   | TableImport tt ->
@@ -549,6 +570,7 @@ module NameSet = Set.Make(struct type t = Ast.name let compare = compare end)
 let check_export (c : context) (set : NameSet.t) (ex : export) : NameSet.t =
   let {name; edesc} = ex.it in
   (match edesc.it with
+  | AbsTypeExport x -> () (* new abstypes can only be created within export statements *)
   | FuncExport x -> ignore (func c x)
   | TableExport x -> ignore (table c x)
   | MemoryExport x -> ignore (memory c x)
@@ -559,6 +581,7 @@ let check_export (c : context) (set : NameSet.t) (ex : export) : NameSet.t =
 
 let check_module (m : module_) =
   let
+    (* Start: Abstract Types *)
     { types; imports; tables; memories; globals; funcs; start; elems; datas;
       exports } = m.it
   in
@@ -566,7 +589,8 @@ let check_module (m : module_) =
     List.fold_right check_import imports
       { empty_context with
         refs = Free.list Free.elem elems;
-        types = List.map (fun ty -> ty.it) types;
+        (* `types` must be declared up front because the FuncImports in check_import may reference them *)
+        types = List.map (fun ty -> ty.it) types; 
       }
   in
   let c1 =

--- a/interpreter/winmake.bat
+++ b/interpreter/winmake.bat
@@ -3,8 +3,8 @@ set NAME=wasm
 if '%1' neq '' set NAME=%1
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I exec -I main -I syntax -I text -I binary -I script -I runtime -I util -I host -I valid -o exec/numeric_error.cmo exec/numeric_error.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I exec -I main -I syntax -I text -I binary -I script -I runtime -I util -I host -I valid -o exec/int.cmo exec/int.ml
-ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I util -I main -I syntax -I text -I binary -I exec -I script -I runtime -I host -I valid -o util/lib.cmi util/lib.mli
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I exec -I main -I syntax -I text -I binary -I script -I runtime -I util -I host -I valid -o exec/i32.cmo exec/i32.ml
+ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I util -I main -I syntax -I text -I binary -I exec -I script -I runtime -I host -I valid -o util/lib.cmi util/lib.mli
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I exec -I main -I syntax -I text -I binary -I script -I runtime -I util -I host -I valid -o exec/float.cmo exec/float.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I syntax -I main -I text -I binary -I exec -I script -I runtime -I util -I host -I valid -o syntax/types.cmo syntax/types.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I exec -I main -I syntax -I text -I binary -I script -I runtime -I util -I host -I valid -o exec/f32.cmo exec/f32.ml
@@ -19,7 +19,9 @@ ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I runtime -I main -I syntax 
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I runtime -I main -I syntax -I text -I binary -I exec -I script -I util -I host -I valid -o runtime/table.cmi runtime/table.mli
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I runtime -I main -I syntax -I text -I binary -I exec -I script -I util -I host -I valid -o runtime/instance.cmo runtime/instance.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I exec -I main -I syntax -I text -I binary -I script -I runtime -I util -I host -I valid -o exec/eval.cmi exec/eval.mli
+ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I runtime -I main -I syntax -I text -I binary -I exec -I script -I util -I host -I valid -o runtime/extern_types.cmo runtime/extern_types.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I binary -I main -I syntax -I text -I exec -I script -I runtime -I util -I host -I valid -o binary/utf8.cmi binary/utf8.mli
+ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I syntax -I main -I text -I binary -I exec -I script -I runtime -I util -I host -I valid -o syntax/types_shorthand.cmo syntax/types_shorthand.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I host -I main -I syntax -I text -I binary -I exec -I script -I runtime -I util -I valid -o host/env.cmo host/env.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I main -I syntax -I text -I binary -I exec -I script -I runtime -I util -I host -I valid -o main/flags.cmo main/flags.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I script -I main -I syntax -I text -I binary -I exec -I runtime -I util -I host -I valid -o script/import.cmi script/import.mli
@@ -55,6 +57,7 @@ ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I runtime -I main -I syntax 
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I exec -I main -I syntax -I text -I binary -I script -I runtime -I util -I host -I valid -o exec/f32_convert.cmo exec/f32_convert.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I exec -I main -I syntax -I text -I binary -I script -I runtime -I util -I host -I valid -o exec/f64_convert.cmo exec/f64_convert.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I exec -I main -I syntax -I text -I binary -I script -I runtime -I util -I host -I valid -o exec/i32_convert.cmo exec/i32_convert.ml
+ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I syntax -I main -I text -I binary -I exec -I script -I runtime -I util -I host -I valid -o syntax/free.cmi syntax/free.mli
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I syntax -I main -I text -I binary -I exec -I script -I runtime -I util -I host -I valid -o syntax/operators.cmo syntax/operators.ml
 ocamlyacc text/parser.mly
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I text -I main -I syntax -I binary -I exec -I script -I runtime -I util -I host -I valid -o text/parser.cmi text/parser.mli
@@ -67,9 +70,10 @@ ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I script -I main -I syntax -
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I text -I main -I syntax -I binary -I exec -I script -I runtime -I util -I host -I valid -o text/parse.cmo text/parse.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I text -I main -I syntax -I binary -I exec -I script -I runtime -I util -I host -I valid -o text/print.cmo text/print.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I valid -I main -I syntax -I text -I binary -I exec -I script -I runtime -I util -I host -o valid/valid.cmo valid/valid.ml
+ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I syntax -I main -I text -I binary -I exec -I script -I runtime -I util -I host -I valid -o syntax/free.cmo syntax/free.ml
 ocamllex.opt -q text/lexer.mll
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I text -I main -I syntax -I binary -I exec -I script -I runtime -I util -I host -I valid -o text/lexer.cmo text/lexer.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I text -I main -I syntax -I binary -I exec -I script -I runtime -I util -I host -I valid -o text/parser.cmo text/parser.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I text -I main -I syntax -I binary -I exec -I script -I runtime -I util -I host -I valid -o text/arrange.cmo text/arrange.ml
 ocamlc.opt -c -w +a-3-4-27-42-44-45 -warn-error +a -I util -I main -I syntax -I text -I binary -I exec -I script -I runtime -I host -I valid -o util/sexpr.cmo util/sexpr.ml
-ocamlc.opt bigarray.cma -I util -I binary -I exec -I syntax -I runtime -I host -I main -I script -I text -I valid util/lib.cmo binary/utf8.cmo exec/float.cmo exec/f32.cmo exec/f64.cmo exec/numeric_error.cmo exec/int.cmo exec/i32.cmo exec/i64.cmo exec/i32_convert.cmo exec/f32_convert.cmo exec/i64_convert.cmo exec/f64_convert.cmo syntax/types.cmo syntax/values.cmo runtime/memory.cmo util/source.cmo syntax/ast.cmo exec/eval_numeric.cmo runtime/func.cmo runtime/global.cmo runtime/table.cmo runtime/instance.cmo util/error.cmo exec/eval.cmo host/env.cmo host/spectest.cmo main/flags.cmo script/import.cmo binary/encode.cmo syntax/operators.cmo binary/decode.cmo script/script.cmo text/parser.cmo text/lexer.cmo text/parse.cmo script/js.cmo util/sexpr.cmo text/arrange.cmo text/print.cmo valid/valid.cmo script/run.cmo main/main.cmo -o main/main.byte
+ocamlc.opt bigarray.cma -I util -I binary -I exec -I syntax -I runtime -I main -I host -I script -I text -I valid util/lib.cmo binary/utf8.cmo exec/float.cmo exec/f32.cmo exec/f64.cmo exec/numeric_error.cmo exec/int.cmo exec/i32.cmo exec/i64.cmo exec/i32_convert.cmo exec/f32_convert.cmo exec/i64_convert.cmo exec/f64_convert.cmo syntax/types.cmo syntax/values.cmo runtime/memory.cmo util/source.cmo syntax/ast.cmo exec/eval_numeric.cmo main/flags.cmo runtime/func.cmo runtime/global.cmo runtime/table.cmo runtime/instance.cmo runtime/extern_types.cmo util/error.cmo exec/eval.cmo host/env.cmo syntax/types_shorthand.cmo host/spectest.cmo script/import.cmo syntax/free.cmo binary/encode.cmo syntax/operators.cmo binary/decode.cmo script/script.cmo text/parser.cmo text/lexer.cmo text/parse.cmo script/js.cmo util/sexpr.cmo text/arrange.cmo text/print.cmo valid/valid.cmo script/run.cmo main/main.cmo -o main/main.byte

--- a/test/core/abstract-types.wast
+++ b/test/core/abstract-types.wast
@@ -1,0 +1,60 @@
+;; Abstract Types
+
+(module $MOD_1
+  (abstype_new $Token i32)
+  (type (;0;) (func (param i32) (result (abstype_new_ref $Token))))
+  (type (;1;) (func (param (abstype_new_ref $Token))))
+  (global $favToken (mut (abstype_new_ref $Token)) (i32.const 0))
+  (global $sum (mut i32) (i32.const 0))
+  (func $createToken (type 0)
+    (local.get 0)
+  )
+  (func $useToken (type 1)
+    (local.get 0)
+    (global.get $sum)
+    (i32.add)
+    (global.set $sum)
+  )
+  ;; TODO disallow exporting a new abstype twice
+  (export "Token" (abstype_new_ref $Token))
+  (export "favToken" (global $favToken))
+  (export "createToken" (func $createToken))
+  (export "useToken" (func $useToken))
+)
+(register "MOD_1" $MOD_1)
+
+(module
+  (import "MOD_1" "Token" (abstype_sealed $Token))
+  (abstype_new $Coin i32)
+  (type (;0;) (func (param i32) (result (abstype_sealed_ref $Token))))
+  (type (;1;) (func (param (abstype_sealed_ref $Token)))) ;; SealedAbsType 0
+  (type (;2;) (func (result (abstype_new_ref $Coin)))) ;; i32
+  (import "MOD_1" "createToken" (func $mod1_createToken (type 0)))
+  (import "MOD_1" "useToken" (func $mod1_useToken (type 1)))
+  (func $f (type 2)
+    (i32.const 42)
+    (call $mod1_createToken)
+    (call $mod1_useToken)
+    (i32.const 1)
+  )
+  (export "Coin" (abstype_new_ref $Coin))
+  (export "f" (func $f))
+)
+
+;; 
+
+(assert_invalid
+  (module
+    (import "MOD_1" "Token" (abstype_sealed $Token))
+    (type (;0;) (func (param (abstype_sealed_ref $Token))))
+    (func $useToken (import "MOD_1" "useToken") (type 0))
+    (func $f
+      (i32.const 42)
+      (call $useToken)
+    )
+  )
+  "type mismatch"
+)
+
+;; TODO test call_indirect w/ abstypes
+;; TODO test invoke

--- a/test/core/abstract-types.wast
+++ b/test/core/abstract-types.wast
@@ -1,60 +1,200 @@
 ;; Abstract Types
 
-(module $MOD_1
-  (abstype_new $Token i32)
-  (type (;0;) (func (param i32) (result (abstype_new_ref $Token))))
-  (type (;1;) (func (param (abstype_new_ref $Token))))
-  (global $favToken (mut (abstype_new_ref $Token)) (i32.const 0))
-  (global $sum (mut i32) (i32.const 0))
-  (func $createToken (type 0)
-    (local.get 0)
-  )
-  (func $useToken (type 1)
-    (local.get 0)
-    (global.get $sum)
-    (i32.add)
-    (global.set $sum)
-  )
-  ;; TODO disallow exporting a new abstype twice
-  (export "Token" (abstype_new_ref $Token))
-  (export "favToken" (global $favToken))
-  (export "createToken" (func $createToken))
-  (export "useToken" (func $useToken))
+(module $Mf
+  (abstype_new $a i32)
+  (export "a" (abstype_new_ref $a))
+  (func (export "out") (result (abstype_new_ref $a)) (i32.const 42))
+  (func (export "in") (param (abstype_new_ref $a)))
 )
-(register "MOD_1" $MOD_1)
+(register "Mf" $Mf)
+
+(assert_unlinkable
+  (module (import "Mf" "out" (func $out (result i32))))
+  "incompatible import type"
+)
+
+(assert_unlinkable
+  (module (import "Mf" "in" (func $in (param i32))))
+  "incompatible import type"
+)
+
+
 
 (module
-  (import "MOD_1" "Token" (abstype_sealed $Token))
-  (abstype_new $Coin i32)
-  (type (;0;) (func (param i32) (result (abstype_sealed_ref $Token))))
-  (type (;1;) (func (param (abstype_sealed_ref $Token)))) ;; SealedAbsType 0
-  (type (;2;) (func (result (abstype_new_ref $Coin)))) ;; i32
-  (import "MOD_1" "createToken" (func $mod1_createToken (type 0)))
-  (import "MOD_1" "useToken" (func $mod1_useToken (type 1)))
-  (func $f (type 2)
-    (i32.const 42)
-    (call $mod1_createToken)
-    (call $mod1_useToken)
-    (i32.const 1)
-  )
-  (export "Coin" (abstype_new_ref $Coin))
-  (export "f" (func $f))
+  (import "Mf" "a" (abstype_sealed $a))
+  (import "Mf" "out" (func $out (result (abstype_sealed_ref $a))))
+  (import "Mf" "in" (func $in (param (abstype_sealed_ref $a))))
 )
-
-;; 
 
 (assert_invalid
   (module
-    (import "MOD_1" "Token" (abstype_sealed $Token))
-    (type (;0;) (func (param (abstype_sealed_ref $Token))))
-    (func $useToken (import "MOD_1" "useToken") (type 0))
-    (func $f
-      (i32.const 42)
-      (call $useToken)
-    )
+    (import "Mf" "a" (abstype_sealed $a))
+    (import "Mf" "out" (func $out (result (abstype_sealed_ref $a))))
+    (func $invalid_call
+      (i32.add (i32.const 17) (call $out)))
   )
-  "type mismatch"
+  "type mismatch: operator requires [i32 i32] but stack has [i32 abs{0}]"
 )
 
-;; TODO test call_indirect w/ abstypes
-;; TODO test invoke
+(assert_invalid
+  (module
+    (import "Mf" "a" (abstype_sealed $a))
+    (import "Mf" "in" (func $in (param (abstype_sealed_ref $a))))
+    (func $invalid_call
+      (call $in (i32.const 0)))
+  )
+  "type mismatch: operator requires [abs{0}] but stack has [i32]"
+)
+
+(module
+  (import "Mf" "a" (abstype_sealed $a))
+  (import "Mf" "out" (func $out (result (abstype_sealed_ref $a))))
+  (import "Mf" "in" (func $in (param (abstype_sealed_ref $a))))
+  (func $call
+    (call $in (call $out)))
+)
+
+
+
+(module $Nf
+  (import "Mf" "a" (abstype_sealed $a))
+  (func (export "use_a") (param (abstype_sealed_ref $a)))
+)
+(register "Nf" $Nf)
+
+(assert_unlinkable
+  (module (import "Nf" "use_a" (func $use_a (param i32))))
+  "incompatible import type"
+)
+
+(module
+  (import "Mf" "a" (abstype_sealed $_a))
+  (import "Nf" "use_a" (func $use_a (param (abstype_sealed_ref $_a))))
+)
+
+
+
+;; NOTICE: sealed abstract types can't be exported; i.e. abstypes can't be reexported (to
+;; simplify resolving abstype references for equality checks; see notes in extern_types.ml
+;; about how abstract types are tied to module instances).
+;;
+;; (module $reexport_a
+;;   (import "Mf" "a" (abstype_sealed $a))
+;;   (export "a2" (abstype_sealed_ref $a))
+;; )
+;; 
+;; (module
+;;   (import "Mf" "a" (abstype_sealed $a))
+;;   (import "reexport_a" "a2" (abstype_sealed $a2))
+;;   (import "Mf" "out" (func $out (result (abstype_sealed_ref $a))))
+;;   (import "Mf" "in" (func $in (param (abstype_sealed_ref $a2))))
+;;   (func $call
+;;     (call $in (call $out)))
+;; )
+
+
+
+;; FIXME: 3rd-party modules are able to use double-sealed abstract types
+;; as if they are the original sealed abstract type, and visa-versa.
+;;
+;; (module $Mf_wrapped
+;;   (import "Mf" "a" (abstype_sealed $a))
+;;   (abstype_new $a_w (abstype_sealed_ref $a))
+;;   (export "a_w" (abstype_new_ref $a_w))
+;;   (import "Mf" "out" (func $Mf_out (result (abstype_sealed_ref $a))))
+;;   (import "Mf" "in" (func $Mf_in (param (abstype_sealed_ref $a))))
+;;   (func (export "out_w") (result (abstype_sealed_ref $a)) (call $Mf_out))
+;;   (func (export "in_w") (param (abstype_sealed_ref $a)) (call $Mf_in (local.get 0)))
+;; )
+;; (register "Mf_wrapped" $Mf_wrapped)
+;; 
+;; (assert_unlinkable
+;;   (module
+;;     (import "Mf_wrapped" "out_w" (func $out (result i32)))
+;;   )
+;;   "incompatible import type"
+;; )
+;; 
+;; (assert_unlinkable
+;;   (module
+;;     (import "Mf_wrapped" "a_w" (abstype_sealed $a_w))
+;;     (import "Mf" "out" (func $out (result (abstype_sealed_ref $a_w))))
+;;   )
+;;   "incompatible import type"
+;; )
+;; 
+;; (assert_unlinkable
+;;   (module
+;;     (import "Mf" "a" (abstype_sealed $a))
+;;     (import "Mf_wrapped" "out_w" (func $out (result (abstype_sealed_ref $a))))
+;;   )
+;;   "incompatible import type"
+;; )
+
+
+
+(module $M2f
+  (abstype_new $a i32)
+  (export "a1" (abstype_new_ref $a))
+  (export "a2" (abstype_new_ref $a))
+  (func (export "out") (result (abstype_new_ref $a)) (i32.const 42))
+  (func (export "in") (param (abstype_new_ref $a)))
+)
+(register "M2f" $M2f)
+
+;; TODO: should abstypes depend on imports or should they resolve be fully resolved to
+;; their (Module Instance * abstype_new) declarations before being compared? If the latter,
+;; then this test module would not be invalid.
+(assert_invalid
+  (module
+    (import "M2f" "a1" (abstype_sealed $a1))
+    (import "M2f" "a2" (abstype_sealed $a2))
+    (import "M2f" "out" (func $M2f_out (result (abstype_sealed_ref $a1))))
+    (import "M2f" "in" (func $M2f_in (param (abstype_sealed_ref $a2))))
+    (func (call $M2f_in (call $M2f_out)))
+  )
+  "type mismatch: operator requires [abs{1}] but stack has [abs{0}]"
+)
+
+
+
+(module $Mt
+  (abstype_new $a i32)
+  (export "a" (abstype_new_ref $a))
+  (type $f_abs (func (result (abstype_new_ref $a))))
+  (func $out (type $f_abs) (i32.const 42))
+  (table (export "table") 10 funcref)
+  (elem (i32.const 0) $out)
+)
+(register "Mt" $Mt)
+
+(module $Mt_no_abs
+  (type $f_raw (func (result i32)))
+  (table (import "Mt" "table") 10 funcref)
+  (func (export "call") (result i32)
+    (call_indirect (type $f_raw) (i32.const 0)))
+)
+(assert_trap (invoke $Mt_no_abs "call") "indirect call type mismatch")
+
+(module $Mt_abs
+  (import "Mt" "a" (abstype_sealed $a))
+  (type $f_abs (func (result (abstype_sealed_ref $a))))
+  (table (import "Mt" "table") 10 funcref)
+  (func (export "call") (result (abstype_sealed_ref $a))
+    (call_indirect (type $f_abs) (i32.const 0)))
+)
+
+
+
+;; FIXME: global imports aren't enforcing abstract types.
+;;
+;; (module $Mg
+;;   (abstype_new $a1 i32)
+;;   (global $g1 (export "g1") (abstype_new_ref $a1) (i32.const 0))
+;; )
+;; (register "Mg" $Mg)
+;; 
+;; (assert_unlinkable
+;;   (module (global $Mg_g1 (import "Mg" "g1") i32))
+;;   "incompatible import type"
+;; )


### PR DESCRIPTION
I don't expect this to be particularly useful to anyone, especially with the exciting work going on with the [GC proposal](https://github.com/WebAssembly/gc/blob/master/proposals/gc/Overview.md) and [Type Imports proposal](https://github.com/WebAssembly/proposal-type-imports/blob/master/proposals/type-imports/Overview.md), but I wanted to share this **abstract types** language extension I implemented in case it is relevant to someone.

_You can launch a Jupyter notebook with several examples and a modified Wasm interpreter implementing the following features by clicking [![launch Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/awendland/2020-thesis/HEAD?filepath=samples/samples.ipynb)._

## Overview

I've implemented a small extension to the WebAssembly language that introduces abstract types (also known as "existential types" or "abstract data types" or "opaque references" or "nominal types"). I built this in the context of my [undergraduate thesis](https://github.com/awendland/2020-thesis) which explored using WebAssembly as a multi-language platform (by enabling the various features needed for secure compilation).

This implementation of abstract types is based on [OCaml's abstract types](https://ocaml.org/learn/tutorials/modules.html#Abstract-types) and loosely conforms with the ideas expressed by **rossberg** and **RossTate** in https://github.com/WebAssembly/proposal-type-imports/issues/7:

* Abstract types are owned by modules.
* The module that creates the abstract types can manipulate them directly as their underlying types.
* Abstract types become "sealed" once exported from the module, meaning that importing modules can't manipulate their values directly.
* There is no sub-typing.

These features allow WebAssembly to enforce higher-level abstractions such as:

* Unforgeable file handles (e.g. in [WASI](https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/witx/typenames.witx#L277))
* Object types (i.e. allowing functions to only operate on a given Object)
* Object references (i.e. unforgeable addresses, e.g. referring to `a` in `let a = new Date(); a.getYear()`)

## Usage

To work with these new abstract types, I've introduced 4 operators to the language. The syntax is verbose in order to ensure clarity in the operations being performed. It's likely that a more ergonomic syntax would be adopted, such as merging the `abstype_new` and `abstype_sealed` namespaces and referring to them with a single operator, as well as overloading the existing `type` instruction to support abstract types. For now, the syntax is as follows:

|                      |                                       |                    |
|----------------------|---------------------------------------|--------------------|
| `abstype_new`        | `abstype_new [IDENTIFIER] value_type` | Create a new abstract type around a given value_type (which can be another abstract type via `abstype_sealed_ref`) |
| `abstype_sealed`     | `abstype_sealed [IDENTIFIER]`         | Import a foreign abstract type. Always used within an `import` instruction, i.e. `(import "mod" "id" (abstype_sealed [IDENTIFIER]))` |
| `abstype_new_ref`    | `abstype_new_ref IDENTIFIER`          | Reference a local abstract type (i.e. one locally declared using `abstype_new`) |
| `abstype_sealed_ref` | `abstype_sealed_ref IDENTIFIER`       | Reference an imported foreign abstract type (i.e. one imported via `abstype_sealed`) |

Abstract types manifest in two ways:

* _Local_ - Local abstract types are at play when `abstype_new*` instructions are used within a given module. These abstract types are "unwrapped" within the module, and are treated as their underlying value_types. In this way, local abstract types are more like type aliases. This allows abstract types to be constructed, and only take on their abstract nature when used in a separate module.
* _Foreign / Sealed_ - Foreign, or sealed, abstract types are present when `abstype_sealed*` instructions are being used. These abstract types are treated as opaque identifiers referencing the source module instance and the export statement. These abstract types are only treated as their underlying values upon program execution (i.e. after validation). Additionally, they do not have default values, so trying to immediately use a `local` with a sealed abstract type will fail, instead, the `local` must be populated with a value provided by the sealed abstract type's source module.

## Examples

You can see simple syntax/usage examples in the test file for this feature at [test/core/abstract-types.wast](https://github.com/awendland/webassembly-spec-abstypes/pull/4/files#diff-eb60d69f8f269dcc0f26a29d12cbe89d30a6ec9322a174227fdd8e90f27d8185).

For something more interesting, I've configured my [awendland/2020-thesis](https://github.com/awendland/2020-thesis) repository to be runnable via [Binder](https://mybinder.org) so that you can jump right into a web-based Jupyter notebook with this `webassembly-spec-abstypes` interpreter already available and the code in `samples/` all runnable. Try it out with: [![launch Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/awendland/2020-thesis/HEAD?filepath=samples/samples.ipynb)

## Implementation Details

I've created a PR (https://github.com/awendland/webassembly-spec-abstypes/pull/4) showcasing the implementation on top of the reference interpreter's Reference Types Proposal branch.

The core changes for stack type checking were in [interpreter/syntax/types.ml](https://github.com/awendland/webassembly-spec-abstypes/pull/4/files#diff-2c71744f4a25497ad85004311595d93b3bc52a1324131e76da2a3b8c5b9cb872):

* adding `SealedAbsType of int32` to `value_type`
* introducing a new layer on top of `value_type` called `wrapped_value_types` that could be a `NewAbsType of value_type * int32` in addition to a straight `value_type`.

In both of these instances, the `i32` value represents a unique identifier for the abstract type, since the types are "nominal", as in, even if they have the same underlying type they're unique if they are from different definitions (i.e. different `abstype_new` operations). See the test suite where this distinction is demonstrated.

The core changes for type checking module linking were implemented in a new module called [interpreter/runtime/extern_types.ml](https://github.com/awendland/webassembly-spec-abstypes/pull/4/files#diff-319c5ce90fc107d0c6eeec3c4523063c6ffceac30df9f1559880b9c7cbac92d0) that:

* replaces [extern_type_of in runtime/instance.ml](https://github.com/awendland/webassembly-spec-abstypes/pull/4/files#diff-515c66e3874d0d04a404e6ec8c1dccca476eb92aee9859495709c677e0cf69d4L53)
* handles comparing abstract types, which may either be "resolved" or "unresolved" since, fundamentally, abstract types are based on Module (or Host) instances, not module definitions.
  * There are additional constructors (NameModuleRef,  LocalModuleRef) which exist to assist with representing abstract types in contexts were modules haven't been instantiated yet, but these representations of abstract types have to be resolved before they can be properly compared.

All uses of `value_type` (should) have been expanded to support abstract types.

## Work in Progress

Several aspects of this implementation are unfinished (and likely to remain so given the exciting development going on with the [GC Proposal](https://github.com/WebAssembly/gc/blob/master/proposals/gc/Overview.md) and my interests moving elsewhere). I documented the issues I was aware of in the test suite; they are:

* Enforcement of type sealing when a sealed/foreign abstract type is used as the value for another new abstract type. 3rd party modules are able to use these double-sealed abstract types as if they were the original sealed abstract type and visa-versa.
* Enforcement of abstract types for globals. You can import a global as its underlying type and the module linking process will succeed just fine (it should have thrown a linking error saying "incompatible import type").

Additionally, I only implemented abstract types for the textual representation of WebAssembly, not the binary variant or the JS API. The binary variant should be a straightforward addition. The JS API will require various decisions to be made around how to enforce the abstraction across the JS boundary; hard problems that are getting compelling answers in the [GC Proposal](https://github.com/WebAssembly/gc/blob/master/proposals/gc/Overview.md).

## Related Discussions

This small language extension is related to much more exciting discussions going on elsewhere, such as:

* https://github.com/WebAssembly/design/issues/1343 - "call_indirect versus abstraction"
* https://github.com/WebAssembly/proposal-type-imports/issues/7 - "Instantiating abstract types"
* https://github.com/WebAssembly/design/issues/1375 - "Thoughts on improving Compilation Model"
* https://github.com/WebAssembly/interface-types/issues/128 - "Guaranteeing additional soundness properties"

It's also loosely related to much grander proposals that are in the works: [GC](https://github.com/WebAssembly/gc/blob/master/proposals/gc/Overview.md), [Type Imports](https://github.com/WebAssembly/proposal-type-imports/blob/master/proposals/type-imports/Overview.md), [Interface Types](https://github.com/WebAssembly/interface-types/blob/master/proposals/interface-types/Explainer.md).

Thanks for such great work on WebAssembly! I'm excited to see where the language goes.